### PR TITLE
Fix E154: Duplicate tag vimproc in file HOME/.vim/.neobundle/doc/vimproc.txt

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -96,3 +96,4 @@ HISTORY
     2013/05/01 (1.3.4) replace '&mdash;' to '--' for easy_html_view (#9)
     2013/05/01 (1.3.5) append g:gmail_show_log_window for debug
     2013/07/07 (1.3.6) 'c' should not be mapped when composing emails.(#12)
+    2014/07/04 (1.3.7) fix E154: Duplicate tag vimproc in file $HOME/.vim/.neobundle/doc/vimproc.txt

--- a/README.md
+++ b/README.md
@@ -123,4 +123,5 @@ HISTORY
     2013/05/01 (1.3.4) replace '&mdash;' to '--' for easy_html_view (#9)
     2013/05/01 (1.3.5) append g:gmail_show_log_window for debug
     2013/07/07 (1.3.6) 'c' should not be mapped when composing emails.(#12)
+    2014/07/04 (1.3.7) fix E154: Duplicate tag vimproc in file $HOME/.vim/.neobundle/doc/vimproc.txt
 

--- a/doc/gmailvim.txt
+++ b/doc/gmailvim.txt
@@ -31,12 +31,12 @@ Please refer to the README.md as a quick reference.
 ==============================================================================
 2. Requirements                                        *gmailvim-requirements*
 
-*vimproc*
+* vimproc
         Interactive command execution in Vim.
 
         - https://github.com/Shougo/vimproc
 
-*openssl*
+* openssl
         A toolkit implementing SSL v2/v3 and TLS protocols with full-strength
         cryptography world-wide.  I have been tested to work with openssl
         included in msysgit for Windows.
@@ -110,7 +110,7 @@ USAGE                                                         *gmailvim-usage*
         This variable specify the number of lines at mail-list-window.
         Default: 10
 
-        Note: Gmail's Fetch is very slow. Therefore, you should not 
+        Note: Gmail's Fetch is very slow. Therefore, you should not
               increase much good.
 
 *g:gmail_default_mailbox*
@@ -171,7 +171,7 @@ There are mappings in gmail.vim.
 5.1. Mailbox
 
 NORMAL MODE                                        *gmailvim-mappings-mailbox*
-<CR> 
+<CR>
         Open the mailbox under the cursor.
 
 u
@@ -188,7 +188,7 @@ c
 5.2. Mail list
 
 NORMAL MODE                                           *gmailvim-mappings-list*
-<CR> 
+<CR>
         Open the mail under the cursor. If the cursor is top, execute menu
         under the cursor.
 
@@ -230,7 +230,7 @@ x
 5.3. Mail preview
 
 NORMAL MODE                                        *gmailvim-mappings-preview*
-<CR> 
+<CR>
         Open the mail under the cursor.
 
 <TAB>
@@ -305,7 +305,7 @@ NORMAL MODE                                        *gmailvim-mappings-preview*
 ==============================================================================
 7. Todo                                                        *gmailvim-todo*
 
-* Attachment file 
+* Attachment file
     - プレビュー表示時は添付ファイルは受信しないようにする。
     - 添付ファイルの保存
     - メール送信時に添付ファイルをつけて送れるようにする。


### PR DESCRIPTION
- Fix E154: Duplicate tag vimproc in file HOME/.vim/.neobundle/doc/vimproc.txt
- Remove wasted space
